### PR TITLE
Add support for .NET 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,14 +12,14 @@ pool:
   vmImage: windows-latest
 steps:
 - task: UseDotNet@2
-  displayName: Install .NET 5 SDK
+  displayName: Install .NET 6 SDK
   inputs:
-    version: '5.0.x'
+    version: '6.0.x'
     packageType: sdk
 - task: UseDotNet@2
-  displayName: Install .NET Core 2.1 SDK
+  displayName: Install .NET Core 3.1 SDK
   inputs:
-    version: '2.1.x'
+    version: '3.1.x'
     packageType: sdk
 - powershell: ./build.ps1 -ci
   displayName: Invoke build.ps1

--- a/src/XUnit.CommandLine/XUnit.CommandLine.csproj
+++ b/src/XUnit.CommandLine/XUnit.CommandLine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net5.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageId>xunit-cli</PackageId>
     <ToolCommandName>xunit</ToolCommandName>

--- a/src/XUnit.CommandLine/XUnit.CommandLine.csproj
+++ b/src/XUnit.CommandLine/XUnit.CommandLine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageId>xunit-cli</PackageId>
     <ToolCommandName>xunit</ToolCommandName>


### PR DESCRIPTION
Added support for .NET 6.

Along the same lines as was done in https://github.com/natemcmaster/xunit-cli/pull/4 I kept some of the other targets intact however I removed ones which were giving out of support warnings. This change aims to address issue  https://github.com/natemcmaster/xunit-cli/issues/5.